### PR TITLE
TAP-compatible test function

### DIFF
--- a/fn/iscallable/iscallable.adoc
+++ b/fn/iscallable/iscallable.adoc
@@ -1,0 +1,35 @@
+== iscallable
+
+[source,lua]
+----
+function iscallable( maybeFunc ) --> callableBool
+----
+
+== Description
+
+This function checks if the argument is callable trhough the standard function call
+syntax.
+
+== Parameters
+
+maybeFunc::
+
+== Return Values
+
+It returns `true` if the argument can be callad trhough the standard function call
+syntax. `false` Otherwise.
+
+== Code
+
+[source,lua]
+----
+include::iscallable.lua[]
+----
+
+== Examples
+
+[source,lua]
+----
+include::iscallable.ex1.lua[]
+----
+

--- a/fn/iscallable/iscallable.ex1.lua
+++ b/fn/iscallable/iscallable.ex1.lua
@@ -1,0 +1,29 @@
+
+local tt = require 'taptest'
+local ic = require 'iscallable'
+
+tt( ic(0),              false )
+tt( ic(''),             false )
+tt( ic(true),           false )
+tt( ic({}),             false )
+tt( ic(function() end), true )
+
+local calltab_a = {}
+setmetatable(calltab_a, {__call = function() end})
+
+tt( ic(calltab_a),      true )
+
+local calltab_b = {}
+setmetatable(calltab_b, {__call = calltab_a})
+
+tt( ic(calltab_b),      true )
+
+local rectab_a = {}
+local rectab_b = {}
+setmetatable(rectab_a, {__call = rectab_b } )
+setmetatable(rectab_b, {__call = rectab_a} )
+
+tt( ic(rectab_b),       false )
+
+tt( )
+

--- a/fn/iscallable/iscallable.lua
+++ b/fn/iscallable/iscallable.lua
@@ -1,0 +1,23 @@
+--ZFUNC-iscallable-v1
+
+local function iscallable_rec(mask, i)
+
+  if 'function' == type(i) then return true end
+
+  local mt = getmetatable(i)
+  if not mt then return false end
+  local callee = mt.__call
+  if not callee then return false end
+
+  if mask[i] then return false end
+  mask[i] = true
+
+  return iscallable_rec(mask, callee)
+end
+
+local function iscallable(i) --> callableBool
+  return iscallable_rec({}, i)
+end
+
+return iscallable
+

--- a/fn/lambda/lambda.adoc
+++ b/fn/lambda/lambda.adoc
@@ -1,0 +1,57 @@
+== lambda
+
+[source,lua]
+----
+function lambda( defStr ) --> func, err
+----
+
+== Description
+
+Define functions using a compact lambda-like syntax.
+
+This function internally works by expanding the following patterns into a
+standard lua function definition. Then it is parsed by the common lua
+load/loadstring function.
+
+The fundamental expanded pattern is 'prologue|statement;expression'.
+
+It generate a function that has 'prologue' as nominal arguments. It can be a
+comma separated list, like in 'x,y,z|statement;expression'.
+
+Then the 'statement' will be injected as the function body. It must be a
+sequence of lua statements like in 'prologue|for k = 1,10 do print(k) end
+print("ok");expression'.
+
+At end of the function the 'expression' will be returned. So it must be a valid
+lua expression like in 'prologue|statement;math.random(2)'.
+
+When the 'prologue' is missing, a default one will be used consisting of the
+first 6 alphabet letters. 'expression' must always be given but the 'statement'
+and the separation ';' can be missing. Indeed, in the main use case, prologue
+and statement will be missing and only the expression will be given.
+
+== Parameters
+
+defStr::
+This is the string containing the function definition. The syntax is
+described in the previous section.
+
+== Return Values
+
+A new function is returned, behaving accordly the 'defStr'. In case of error,
+nil will be returned plus an error message.
+
+== Code
+
+[source,lua]
+----
+include::lambda.lua[]
+----
+
+== Examples
+
+[source,lua]
+----
+ include::lambda.ex1.lua[]
+----
+

--- a/fn/lambda/lambda.ex1.lua
+++ b/fn/lambda/lambda.ex1.lua
@@ -1,0 +1,15 @@
+
+local l = require( "lambda" )
+local test = require( "taptest" )
+
+-- lambda-like syntax
+test( 1, l'x|x+1'(0) )
+
+-- additional statement, only the last expression is returned
+test( 3, l'x| x=x+1; x+1'(1) )
+
+-- default args are a,b,c,d,e,f,...(vararg)
+test( 1, l'a+1'(0) )
+
+test()
+

--- a/fn/lambda/lambda.lua
+++ b/fn/lambda/lambda.lua
@@ -1,0 +1,38 @@
+--ZFUNC-lambda-v1
+local function lambda(def) --> func
+
+  -- Compatibility wrapper
+  local function compat_load(chunk)
+    local chunkname = 'lambda'
+    if _VERSION ~= 'Lua 5.1' then
+      return load(chunk, chunkname, 't')
+    else
+      return loadstring(chunk, chunkname)
+    end
+  end
+
+  -- Find the body and symbolic arguments
+  local symb, body = def:match('^(.-)|(.*)$')
+  if not arg or not body then
+    symb = 'a,b,c,d,e,f,...'
+    body = def
+  end
+
+  -- Split statements from the last expression
+  local stat, expr = body:match('^(.*;)([^;]*)$')
+
+  -- Generate standard lua function definition
+  local func = 'return(function(' .. symb .. ')'
+  if not expr or expr == '' then
+    func = func .. 'return ' .. body
+  else
+    func = func .. stat .. 'return ' .. expr
+  end
+  func = func .. ' end)(...)'
+
+  -- Generate the function
+  return compat_load(func)
+end
+
+return lambda
+

--- a/fs/isreadable/isreadable.adoc
+++ b/fs/isreadable/isreadable.adoc
@@ -1,0 +1,35 @@
+== isreadable
+
+[source,lua]
+----
+function isreadable( pathStr, ... ) --> readableStr
+----
+
+== Description
+
+Find the first argument that is the path to a readable file.
+
+== Parameters
+
+path::
+One or more (vararg) strings containing a filesystem path to check.
+
+== Return Values
+
+It returns `nil` if no one of the supplied path is a readable file. Otherwise it
+returns the first path that corresponds to a readable file.
+
+== Code
+
+[source,lua]
+----
+include::isreadable.lua[]
+----
+
+== Examples
+
+[source,lua]
+----
+include::isreadable.ex1.lua[]
+----
+

--- a/fs/isreadable/isreadable.ex1.lua
+++ b/fs/isreadable/isreadable.ex1.lua
@@ -1,0 +1,20 @@
+
+local tt = require 'taptest'
+local ir = require 'isreadable'
+
+os.remove('read_test.txt')
+
+tt( ir( 'read_test.txt' ), false )
+
+io.open('read_test.txt', 'wb'):close()
+
+tt( ir( 'read_test.txt' ), 'read_test.txt' )
+
+os.remove('read_test_b.txt')
+
+tt( ir( 'read_test_b.txt'), false )
+tt( ir( 'read_test_b.txt', 'read_test.txt'),   'read_test.txt' )
+tt( ir( 'read_test.txt',   'read_test_a.txt'), 'read_test.txt' )
+
+tt( )
+

--- a/fs/isreadable/isreadable.lua
+++ b/fs/isreadable/isreadable.lua
@@ -1,0 +1,19 @@
+--ZFUNC-isreadable-v1
+--
+local function isreadable_single(path)
+  local f = io.open(path, 'r')
+  if not f then return false end
+  f:close()
+  return path
+end
+
+local function isreadable(...) --> readableStr
+  for i = 1, select('#', ...) do
+    local readableStr = isreadable_single(select(i, ...))
+    if readableStr then return readableStr end
+  end
+  return false
+end
+
+return isreadable
+

--- a/num/isinteger/isinteger.adoc
+++ b/num/isinteger/isinteger.adoc
@@ -1,0 +1,34 @@
+== isinteger
+
+[source,lua]
+----
+function isinteger( maybeInt ) --> bool
+----
+
+== Description
+
+Check if the argument is an integer or not.
+
+== Parameters
+
+maybeInt::
+Argument to check.
+
+== Return Values
+
+It return `true` if the argument is and integer or `false` otherwise.
+
+== Code
+
+[source,lua]
+----
+include::isinteger.lua[]
+----
+
+== Examples
+
+[source,lua]
+----
+include::isinteger.ex1.lua[]
+----
+

--- a/num/isinteger/isinteger.ex1.lua
+++ b/num/isinteger/isinteger.ex1.lua
@@ -1,0 +1,14 @@
+
+local tt = require 'taptest'
+local ii = require 'isinteger'
+
+tt( ii(1),    true )
+tt( ii(0),    true )
+tt( ii(1.1),  false )
+tt( ii('1'),  false )
+tt( ii(true), false )
+tt( ii({1}),  false )
+tt( ii(),     false )
+
+tt( )
+

--- a/num/isinteger/isinteger.lua
+++ b/num/isinteger/isinteger.lua
@@ -1,0 +1,9 @@
+--ZFUNC-isinteger-v1
+local function isinteger(i) --> bool
+  if 'number' ~= type(i) then return false end
+  local i, f = math.modf(i)
+  return (0 == f)
+end
+
+return isinteger
+

--- a/str/logline/logline.adoc
+++ b/str/logline/logline.adoc
@@ -1,0 +1,76 @@
+== logline
+
+[source,lua]
+----
+function logline( level, messageStr, ... ) --> logStr
+function logline( level ) --> nil
+----
+
+== Description
+
+This function adds common useful information to the data that you want to
+output.
+
+When called with a single argument, it will set the global verbosity level.
+When called with additional arguments it will generate the log string. However
+the string will be generated only if the first argument, the line log level, is
+smaller than the global verbosity level. In this way you can dinamically enable
+or disable log messages in critical part of the code.
+
+The verbosity level can be given in two way: as an integer or as a string
+representing the verbosity class. The allowed verbosity classes are:
+- ERROR <-> 25
+- DEBUG <-> 50
+- INFO <-> 75
+- VERBOSE <-> 99
+
+Each class will be considered to cantain any integer level just below it, e.g.
+26, 30 and 50 all belongs to the "DEBUG" class. When specifying the verbosity level
+as a class name, the higher belonging integer will be used.
+
+== Parameters
+
+level::
+Integer verbosity level or string verbosity class name.  When called without
+any other argument this is the global verbosity level to be set. If other
+arguments are present, it is the verbosity level of the log line.  Note that
+the output will be generated only if the line have a level smaller than the
+global verbosity.
+
+messageStr::
+Additional information that will be appended to the output. More than one
+arguments can be passed (vararg), all of them will be appended.
+
+== Return Values
+
+It return nil if called with one arguments o if the global verbosity level is
+not high enough. Otherwise it will return a string containing:
+- Date
+- Time
+- os.clock() result
+- Incremental number
+- Verbosity level of the log line
+- Source position of function call
+- Additional info in the arguments
+
+Note 1: The verbosity level will be reported both as number that as the
+symbolic class name.
+
+Note 2: if the caller is a tail call or a function with a name that starts or
+ends with 'log', the position used will be the one of the caller of the caller
+(and so on).
+
+== Code
+
+[source,lua]
+----
+include::logline.lua[]
+----
+
+== Examples
+
+[source,lua]
+----
+ include::logline.ex1.lua[]
+----
+

--- a/str/logline/logline.ex1.lua
+++ b/str/logline/logline.ex1.lua
@@ -1,0 +1,93 @@
+
+local logline = require 'logline'
+local tt = require 'taptest'
+
+-- The checker: when verifing strings use pattern matchin
+-- Otherwise fallback to ==
+local function pcheck(got, exp)
+  if type(exp) ~= type(got) then return false end
+  if 'string' ~= type(got) then return (got == exp) end
+  return (nil ~= got:match(exp))
+end
+
+-- Default log level is 25 a.k.a. ERROR
+-- Only logline with smaller level will generate a message
+
+tt( logline(10, 'test'), '|', pcheck )
+tt( logline(25, 'test'), '|', pcheck )
+tt( logline(26, 'test'), nil, pcheck )
+tt( logline(99, 'test'), nil, pcheck )
+
+-- Change log level
+logline(60)
+tt( logline(10, 'test'), '|', pcheck )
+tt( logline(60, 'test'), '|', pcheck )
+tt( logline(61, 'test'), nil, pcheck )
+tt( logline(99, 'test'), nil, pcheck )
+
+-- Symbolic log level name
+
+logline('error')
+tt( logline(25, 'test'),        '|', pcheck )
+tt( logline(26, 'test'),        nil, pcheck )
+tt( logline('error', 'test'),   '|', pcheck )
+tt( logline('debug', 'test'),   nil, pcheck )
+tt( logline('info', 'test'),    nil, pcheck )
+tt( logline('verbose', 'test'), nil, pcheck )
+
+logline('debug')
+tt( logline(50, 'test'),        '|', pcheck )
+tt( logline(51, 'test'),        nil, pcheck )
+tt( logline('error', 'test'),   '|', pcheck )
+tt( logline('debug', 'test'),   '|', pcheck )
+tt( logline('info', 'test'),    nil, pcheck )
+tt( logline('verbose', 'test'), nil, pcheck )
+
+logline('info')
+tt( logline(75, 'test'),        '|', pcheck )
+tt( logline(76, 'test'),        nil, pcheck )
+tt( logline('error', 'test'),   '|', pcheck )
+tt( logline('debug', 'test'),   '|', pcheck )
+tt( logline('info', 'test'),    '|', pcheck )
+tt( logline('verbose', 'test'), nil, pcheck )
+
+logline('verbose')
+tt( logline(99, 'test'),        '|', pcheck )
+tt( logline(100, 'test'),       nil, pcheck )
+tt( logline('error', 'test'),   '|', pcheck )
+tt( logline('debug', 'test'),   '|', pcheck )
+tt( logline('info', 'test'),    '|', pcheck )
+tt( logline('verbose', 'test'), '|', pcheck )
+
+-- Message contains source position
+tt( logline(99, 'test'), 'logline%.ex1%.lua:63', pcheck ) -- he line 63 is this one
+
+-- In some case the caller source position is used:
+-- - Tail calls
+-- - Functions with names that start or end with 'log'
+
+function wraplog(...) return logline(99, ...) end
+function wraplogfakebarrier(...) return logline(99, ...) end
+function wraplogbarrier(...)
+  local res = logline(99, ...) -- line 72
+  return res
+end
+
+tt( wraplog('test'),            'logline%.ex1%.lua:76', pcheck ) -- line 76
+tt( wraplogfakebarrier('test'), 'logline%.ex1%.lua:77', pcheck ) -- line 77
+tt( wraplogbarrier('test'),     'logline%.ex1%.lua:72', pcheck )
+
+-- The argument are appended to the result string
+tt( logline(99, 'a', 1), '| a | 1 | $', pcheck )
+
+-- OTHER STUFF IN THE LOG: -- TODO : TEST ?
+-- - date
+-- - time
+-- - os.clock() result
+-- - incremental number
+-- - log level of the line
+
+print('# ' .. logline(80, 'ok'))
+
+tt( )
+

--- a/str/logline/logline.lua
+++ b/str/logline/logline.lua
@@ -1,0 +1,88 @@
+--ZFUNC-logline-v1
+local skip_lower_level = 25
+local log_count = 0
+
+local level_list =  {
+  {25, 'ERROR'},
+  {50, 'DEBUG'},
+  {75, 'INFO'},
+  {99, 'VERBOSE'},
+}
+
+local level_map
+
+local function update_level_map()
+  level_map = {}
+  for k,v in ipairs(level_list) do
+    level_map[ v[2] ] = v
+  end
+end
+
+update_level_map()
+
+local function logline(level, ...) --> logStr
+  local n = select('#', ...)
+
+  -- Classify log level
+  local level_class
+  if 'string' == type(level) then
+    level_class = level_map[level:upper()]
+    if level_class then level = level_class[1] end
+  elseif 'number' == type(level) then
+    local level_num = #level_list
+    for k = 1, level_num do
+      if k == level_num or level <= level_list[k][1] then
+        level_class = level_list[k] 
+        break
+      end
+    end
+  else
+    return nil, 'Invalid type for argument #1'
+  end
+  if not level_class then
+    return nil, 'Invalid symbolic log level'
+  end
+
+  --  Single argument mode: set log level
+  if n == 0 then
+    skip_lower_level = level
+    return
+  end
+
+  -- Multiple argument mode: generate log line
+
+  -- Skip if the current log level is too small
+  if skip_lower_level < level then
+    return
+  end
+  log_count = log_count + 1
+
+  -- Get info about the function in the correct stack position
+  local d = debug.getinfo(2)
+  local td = d
+  local stackup = 2
+  while true do
+    local n = td.name
+    if not n then break end
+    n = n:lower()
+    if not n:match('log$') and not n:match('^log') then break end
+    stackup = stackup + 1
+    td = debug.getinfo(stackup)
+  end
+  if td then d = td end
+
+  -- Log line common part
+  local logStr = os.date("%Y/%m/%d %H:%M:%S")..' '..os.clock()..' '
+    .. log_count .. ' ' .. level_class[1] .. '.' ..level_class[2] .. ' '
+    .. d.short_src:match('([^/\\]*)$') .. ':' .. d.currentline .. ' | '
+
+  -- Append additional log info from arguments
+  for m=1,n do
+    logStr = logStr .. tostring(select(m, ...)) .. ' | '
+  end
+
+  return logStr
+end
+
+return logline
+

--- a/sys/taptest/taptest.adoc
+++ b/sys/taptest/taptest.adoc
@@ -1,0 +1,67 @@
+= taptest
+
+[source,lua]
+----
+function taptest( actual, expect, [ compare, [ message ]] ) --> string
+function taptest( diagnostic ) --> string
+function taptest( ) --> string
+----
+
+== Description
+
+This function behaves differently based on the number of arguments. It can
+check actual values versus expected ones. It can print diagnostic. Or it can
+print tests summary when called without arguments.
+
+All the output is done in the Test Anything Protocol (TAP) format. In case of
+failure some information are appended, like source position, actual value, etc.
+
+For a more detailed explanation of its behaviour, refer to the next section.
+
+== Parameters
+
+actual::
+The actual value got from the code under test.
+
+expect::
+The expected value
+
+compare::
+The compare function. If it is given as 3-rd or 4-th argument, this function
+will be called with 'actual, expected' as argument. If it return true the test
+will be assumed to success, otherwise it will be assumed to be failed. If no
+compare function is given, the '==' operator will be used as default.
+
+message::
+If a message string is given as 3-rd or 4-th argument, it will be appended to
+the TAP formatted line, only in case of failing test. This is ment as a way to
+give additional information about the failure.
+
+diagnostic::
+When called with just one string argument, a TAP diagnostic block will be
+printed. A '#' will be prepended to each line of the diagnostic message.
+
+== Return Values
+
+Returns a string containing the same message written to the stdout. This
+message is a TAP check line or a sequence of TAP diagnostic lines.
+
+== Code
+
+[source,lua]
+----
+include::taptest.lua[]
+----
+
+== Examples
+
+[source,lua]
+----
+ include::taptest.ex1.lua[]
+----
+
+== Inspired by
+
+https://testanything.org/
+https://github.com/telemachus/tapered
+

--- a/sys/taptest/taptest.ex1.lua
+++ b/sys/taptest/taptest.ex1.lua
@@ -1,0 +1,75 @@
+
+-- taptest is both the "Unit under test" (uut) and the "Test framework" (tf)
+local tf = require( "taptest" )
+local uut = require( "taptest" )
+
+-- To avoid confusion (as much as it is possible) tf will be always used in its
+-- easest form: it just checks that the two argument are equals.
+-- Since taptest always returns what it print on stdout, the returned
+-- value of uut is checked
+
+-- wrap the uut to avoid printing test results on the stdout
+local fake_test_count = 1
+local uut_wrapped = uut
+local function uut(...)
+  if 1< select('#', ...) then print('ok '..fake_test_count) end
+  fake_test_count = fake_test_count + 2
+  local _p = print
+  print = function() end
+  local result = uut_wrapped(...)
+  print = _p
+  return result 
+end
+
+tf(
+  uut( 1, 1 ),
+  'ok 1' )
+
+-- Note: since at each line two test will be done (one for uut and one for tf)
+-- the test counter step is 2, not 1
+tf(
+  uut( 1, 1 ),
+  'ok 3' )
+
+-- Additional infos when the test fails
+tf(
+  uut( 1, 2 ),
+  'not ok 5 - @taptest.ex1.lua:19. Expectation [2] does not match with [1]. ' )
+
+-- Custom infos on fail
+tf(
+  uut( 1, 2, 'Not good!' ),
+  'not ok 7 - @taptest.ex1.lua:19. Expectation [2] does not match with [1]. Not good!' )
+
+-- Custom compare function
+tf(
+  uut( 1, 2, function(a,b) return a < b end ),
+  'ok 9' )
+tf(
+  uut( 2, 1, function(a,b) return a < b end ),
+  'not ok 11 - @taptest.ex1.lua:19. Expectation [1] does not match with [2]. ' )
+
+-- Custom compare function and message
+tf(
+  uut( 2, 1, function(a,b) return a < b end, 'Not good!' ),
+  'not ok 13 - @taptest.ex1.lua:19. Expectation [1] does not match with [2]. Not good!' )
+tf(
+  uut( 2, 1, 'Not good!', function(a,b) return a < b end ),
+  'not ok 15 - @taptest.ex1.lua:19. Expectation [1] does not match with [2]. Not good!' )
+
+-- Single argument = Tap diagnostic
+tf(
+  uut( 'new\nsuite' ),
+  '#\n#########\n# new\n# suite' )
+
+-- No argument = Summary and final plan
+tf(
+  uut( ),
+  '#\n#########\n# 5 tests failed\n1..17' )
+
+tf()
+
+-- In case all the tests are successful, the line
+-- # all is right
+-- will be substitued to the '# 5 tests failed' one
+

--- a/sys/taptest/taptest.ex1.lua
+++ b/sys/taptest/taptest.ex1.lua
@@ -34,12 +34,12 @@ tf(
 -- Additional infos when the test fails
 tf(
   uut( 1, 2 ),
-  'not ok 5 - @taptest.ex1.lua:19. Expectation [2] does not match with [1]. ' )
+  'not ok 5 - taptest.ex1.lua:19. Expectation [2] does not match with [1]. ' )
 
 -- Custom infos on fail
 tf(
   uut( 1, 2, 'Not good!' ),
-  'not ok 7 - @taptest.ex1.lua:19. Expectation [2] does not match with [1]. Not good!' )
+  'not ok 7 - taptest.ex1.lua:19. Expectation [2] does not match with [1]. Not good!' )
 
 -- Custom compare function
 tf(
@@ -47,15 +47,15 @@ tf(
   'ok 9' )
 tf(
   uut( 2, 1, function(a,b) return a < b end ),
-  'not ok 11 - @taptest.ex1.lua:19. Expectation [1] does not match with [2]. ' )
+  'not ok 11 - taptest.ex1.lua:19. Expectation [1] does not match with [2]. ' )
 
 -- Custom compare function and message
 tf(
   uut( 2, 1, function(a,b) return a < b end, 'Not good!' ),
-  'not ok 13 - @taptest.ex1.lua:19. Expectation [1] does not match with [2]. Not good!' )
+  'not ok 13 - taptest.ex1.lua:19. Expectation [1] does not match with [2]. Not good!' )
 tf(
   uut( 2, 1, 'Not good!', function(a,b) return a < b end ),
-  'not ok 15 - @taptest.ex1.lua:19. Expectation [1] does not match with [2]. Not good!' )
+  'not ok 15 - taptest.ex1.lua:19. Expectation [1] does not match with [2]. Not good!' )
 
 -- Single argument = Tap diagnostic
 tf(

--- a/sys/taptest/taptest.lua
+++ b/sys/taptest/taptest.lua
@@ -1,0 +1,77 @@
+--ZFUNC-taptest-v1
+
+local test_count = 0
+local fail_count = 0
+
+local function taptest(...) --> msg
+
+  local function diagnostic(desc)
+    local msg = '#\n#########\n# ' .. desc:gsub('\n','\n# ')
+    print(msg)
+    return msg
+  end
+
+  local function print_summary()
+    local msg = ''
+    if fail_count == 0 then
+      msg = msg .. diagnostic('all is right')
+    else
+      msg = msg .. diagnostic(fail_count.. ' tests failed')
+    end
+    local plan = '1..'..test_count
+    print(plan)
+    return msg..'\n'..plan
+  end
+
+  local function do_check(got, expected, a, b)
+
+    -- Extra arg parse and defaults
+    local checker, err
+    if 'string' == type(a) then err = a end
+    if 'string' == type(b) then err = b end
+    if not err then err = '' end
+    if 'function' == type(a) then checker = a end
+    if 'function' == type(b) then checker = b end
+    if not checker then checker = function(e, g) return e == g end end
+
+    -- Check the condition
+    test_count = test_count + 1
+    local ok = checker(got, expected)
+
+    -- Generate TAP line
+    local msg = ''
+    if ok then
+      msg = msg .. 'ok ' .. test_count
+    else
+      fail_count = fail_count + 1
+
+      -- Find position in source
+      local stackup = 2
+      local i = debug.getinfo(stackup)
+      while i.source == '=(tail call)' do
+        stackup = stackup + 1
+        i = debug.getinfo(stackup)
+      end
+
+      msg = msg
+        .. 'not ok ' .. test_count .. ' - '
+        .. i.source:match('([^/\\]*)$') .. ':' .. i.currentline .. '. '
+        .. 'Expectation [' .. tostring(expected) .. '] '
+        .. 'does not match with [' .. tostring(got) ..']. '
+        .. err
+    end
+
+    print(msg)
+    return msg
+  end
+
+  local narg = select('#', ...)
+  if     0 == narg then return print_summary()
+  elseif 1 == narg then return diagnostic(select(1, ...))
+  elseif 4 >= narg then return do_check(...)
+  end
+  return nil, 'Too many arguments'
+end
+
+return taptest
+

--- a/sys/taptest/taptest.lua
+++ b/sys/taptest/taptest.lua
@@ -55,7 +55,7 @@ local function taptest(...) --> msg
 
       msg = msg
         .. 'not ok ' .. test_count .. ' - '
-        .. i.source:match('([^/\\]*)$') .. ':' .. i.currentline .. '. '
+        .. i.source:match('([^@/\\]*)$') .. ':' .. i.currentline .. '. '
         .. 'Expectation [' .. tostring(expected) .. '] '
         .. 'does not match with [' .. tostring(got) ..']. '
         .. err


### PR DESCRIPTION
This time should work. I re-inited the fork repo to keep the history clean.
Some note on the code:

 - I changed the one-argument mode to implement the "Tap diagnostic" since Tap have not the concept of "Suite". However, in my previous implementation, Suite was just logging so, you can reproduce it with Tap diagnostic.
 - Using taptest to test itself make the example a bit confusing. I tryed as much ad possible to clearify the example. Maybe it is better to write a simplier one?
- For now, no argument type check are performed
- I put it in the sys directory, maybe you have some better solution
